### PR TITLE
Remove manifests for already installed resources

### DIFF
--- a/playbooks/k8s-helm-charts.yml
+++ b/playbooks/k8s-helm-charts.yml
@@ -38,10 +38,10 @@
     - name: K8S Helm .:. Download Cert-Manager requirements
       get_url:
         url: https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/deploy/manifests/00-crds.yaml
-        dest: "{{ wai_k8s_deployment_dir }}/crds.yaml"
+        dest: "{{ wai_k8s_deployment_dir }}/helm/crds.yaml"
 
     - name: K8S Helm .:. Install Cert-Manager requirements
-      raw: "{{ wai_kubectl }} apply --validate=false -f {{ wai_k8s_deployment_dir }}/crds.yaml"
+      raw: "{{ wai_kubectl }} apply --validate=false -f {{ wai_k8s_deployment_dir }}/helm/crds.yaml"
 
     - name: K8S Helm .:. Install Cert-Manager
       helm:
@@ -279,3 +279,8 @@
         kubectl: "{{ wai_kubectl }}"
         state: "latest"
         filename: "{{ wai_k8s_deployment_dir }}/99_cluster-issuer.yml"
+
+    - name: K8S Helm .:. Cleanup
+      file:
+        state: absent
+        path: "{{ wai_k8s_deployment_dir }}/helm/"


### PR DESCRIPTION
Rimuove il file `crds.yaml` per evitare che sia processato una seconda volta in `k8s-deployment.yml`