### PR TITLE
Bump ES version

### DIFF
--- a/playbooks/inventory/group_vars/all.yml
+++ b/playbooks/inventory/group_vars/all.yml
@@ -112,7 +112,7 @@ wai_base_https_port: 30443
 
 # Elastic version used for Elasticsearch, Kibana and Beats.
 # These vars override default settings of role elastic.elasticsearch and are used in wai roles kibana 
-es_version: 7.5.1
+es_version: 7.6.0
 es_major_version: 7.x
 es_apt_key: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
 es_apt_url: "deb https://artifacts.elastic.co/packages/{{es_major_version}}/apt stable main"

--- a/playbooks/requirements.yml
+++ b/playbooks/requirements.yml
@@ -1,6 +1,6 @@
 # Elasticsearch
 - src: elastic.elasticsearch
-  version: 7.5.1
+  version: 7.6.0
 
 # Swap
 - src: geerlingguy.swap


### PR DESCRIPTION
Related to https://github.com/pdavide/wai-portal/pull/513.

Release notes: https://www.elastic.co/guide/en/elasticsearch/reference/7.6/release-notes-7.6.0.html