### PR TITLE
Fix 210105

### DIFF
--- a/images/wai-openresty/build.sh
+++ b/images/wai-openresty/build.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
-
-docker build -t webanalyticsitalia/wai-openresty:1.0.0-stable -t webanalyticsitalia/wai-openresty:latest --build-arg OPENRESTY_VERSION=1.19.3.1-2-alpine-fat .
+docker build -t webanalyticsitalia/wai-openresty:1.0.1-stable -t webanalyticsitalia/wai-openresty:latest --build-arg OPENRESTY_VERSION=1.19.3.1-2-alpine-fat .
+docker push webanalyticsitalia/wai-openresty:1.0.1-stable
+docker push webanalyticsitalia/wai-openresty:latest

--- a/images/wai-openresty/wai-csp.lua
+++ b/images/wai-openresty/wai-csp.lua
@@ -13,6 +13,21 @@ local function exit_401()
   ngx.exit(ngx.HTTP_OK)
 end
 
+local function has_value (arg, val)
+  if arg == nil or val == ngx.null then
+    return false
+end
+if type(arg) == "table" then
+  for index, value in ipairs(arg) do
+      if value == val then
+          return true
+      end
+  end
+  return false
+end
+return type(arg) == "string" and arg == val
+end
+
 local waicsp = {
   _VERSION = '0.0.1',
 }
@@ -22,7 +37,7 @@ waicsp.__index = waicsp
 function waicsp.evaluate(opts) 
   local args, err = ngx.req.get_uri_args()
   local cspValue = opts.defaultCsp
-  if (err ~= "truncated" and args["module"] == "Widgetize" and args["action"] == "iframe" and args["widget"] == "1" and args["idSite"] ~= nil ) then
+  if (err ~= "truncated" and has_value(args["module"], "Widgetize") and has_value(args["action"], "iframe") and has_value(args["widget"], "1") and args["idSite"] ~= nil and type(args["idSite"]) == "string") then
     local siteId = args["idSite"]
     ngx_log(ngx_NOTICE, "Parameters are ok. CSP procedure activated")
     local rc = require("resty.redis.connector").new()

--- a/playbooks/inventory/group_vars/all.yml
+++ b/playbooks/inventory/group_vars/all.yml
@@ -200,7 +200,7 @@ wai_matomo_image_tag: 3.14.1-7
 
 # Wai NGINX Openresty
 wai_nginx_openresty: webanalyticsitalia/wai-openresty
-wai_nginx_openresty_tag: 1.0.0-stable
+wai_nginx_openresty_tag: 1.0.1-stable
 
 # WAI Cache Image
 wai_cache_image: varnish

--- a/playbooks/templates/k8s/jail/matomo-jail.yml.j2
+++ b/playbooks/templates/k8s/jail/matomo-jail.yml.j2
@@ -269,10 +269,13 @@ data:
           add_header Cache-Control "public";
         }
 
+{% if matomo_name != 'matomo-api' %}
         location ~* / {
           deny all;
           return 404;
         }
+{% endif %}
+
 {% endif %}
 
         access_log /usr/local/openresty/nginx/logs/access.log combined if=$loggable;


### PR DESCRIPTION
Immagine wai-openresty aggiornata alla 1.0.1-stable risolvendo:
1. Errori 404 ritornati da openresty;
1. Url chiamate con argomenti passati due volte come *widget*  `curl "https://api.play.webanalytics.italia.it/widgets/index.php?module=Widgetize&action=iframe&forceView=1&viewDataTable=sparklines&disableLink=0&widget=1&moduleToWidgetize=VisitsSummary&actionToWidgetize=get&period=range&date=previous30&disableLink=1&widget=1&idSite=100&show_footer_icons=0&show_related_reports=0&language=it"`

