### PR TITLE
Referrer host

### DIFF
--- a/images/wai-openresty/Dockerfile
+++ b/images/wai-openresty/Dockerfile
@@ -1,6 +1,7 @@
 ARG OPENRESTY_VERSION
 FROM openresty/openresty:${OPENRESTY_VERSION}
 
-RUN luarocks install lua-resty-redis-connector
+RUN luarocks install lua-resty-redis-connector && \
+    luarocks install lua-resty-url
 
 COPY wai-csp.lua /usr/local/openresty/lualib/wai/

--- a/images/wai-openresty/build.sh
+++ b/images/wai-openresty/build.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-docker build -t webanalyticsitalia/wai-openresty:1.0.2-stable -t webanalyticsitalia/wai-openresty:latest --build-arg OPENRESTY_VERSION=1.19.3.1-2-alpine-fat .
-docker push webanalyticsitalia/wai-openresty:1.0.2-stable
+docker build -t webanalyticsitalia/wai-openresty:1.1.0-stable -t webanalyticsitalia/wai-openresty:latest --build-arg OPENRESTY_VERSION=1.19.3.1-2-alpine-fat .
+docker push webanalyticsitalia/wai-openresty:1.1.0-stable
 docker push webanalyticsitalia/wai-openresty:latest

--- a/images/wai-openresty/tests/WAI-Openresty.postman_collection.json
+++ b/images/wai-openresty/tests/WAI-Openresty.postman_collection.json
@@ -145,7 +145,7 @@
 							"",
 							"pm.test(\"Content-Security-Policy is present\", function () {",
 							"    pm.response.to.have.header(\"Content-Security-Policy\");",
-							"    pm.expect(pm.response.headers.get(\"Content-Security-Policy\")).to.eq(\"frame-ancestors \" + pm.variables.get(\"default_csp\") + \" https://www.site-one.it https://site-two.it https://site-three.it\");",
+							"    pm.expect(pm.response.headers.get(\"Content-Security-Policy\")).to.eq(\"frame-ancestors \" + pm.variables.get(\"default_csp\") + \" www.site-one.it site-two.it site-three.it\");",
 							"});"
 						],
 						"type": "text/javascript"
@@ -201,7 +201,7 @@
 							"",
 							"pm.test(\"Content-Security-Policy is present\", function () {",
 							"    pm.response.to.have.header(\"Content-Security-Policy\");",
-							"    pm.expect(pm.response.headers.get(\"Content-Security-Policy\")).to.eq(\"frame-ancestors \" + pm.variables.get(\"default_csp\") + \" https://www.site-one.it https://site-two.it https://site-three.it\");",
+							"    pm.expect(pm.response.headers.get(\"Content-Security-Policy\")).to.eq(\"frame-ancestors \" + pm.variables.get(\"default_csp\") + \" www.site-one.it site-two.it site-three.it\");",
 							"});"
 						],
 						"type": "text/javascript"
@@ -257,7 +257,7 @@
 							"",
 							"pm.test(\"Content-Security-Policy is present\", function () {",
 							"    pm.response.to.have.header(\"Content-Security-Policy\");",
-							"    pm.expect(pm.response.headers.get(\"Content-Security-Policy\")).to.eq(\"frame-ancestors \" + pm.variables.get(\"default_csp\") + \" https://www.site-one.it https://site-two.it https://site-three.it\");",
+							"    pm.expect(pm.response.headers.get(\"Content-Security-Policy\")).to.eq(\"frame-ancestors \" + pm.variables.get(\"default_csp\") + \" www.site-one.it site-two.it site-three.it\");",
 							"});"
 						],
 						"type": "text/javascript"

--- a/images/wai-openresty/tests/docker-compose.yml
+++ b/images/wai-openresty/tests/docker-compose.yml
@@ -3,7 +3,10 @@ services:
     redis:
         image: webanalyticsitalia/wai-redisearch
     openresty:
-        image: webanalyticsitalia/wai-openresty:latest
+        build:
+            context: ../
+            args:
+                OPENRESTY_VERSION: 1.19.3.1-2-alpine-fat
         links:
             - redis
         ports:

--- a/images/wai-openresty/tests/test.sh
+++ b/images/wai-openresty/tests/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 docker-compose up -d && \
 sleep 5 && \
-docker-compose exec redis sh -c "echo SET 1 \\\"https://www.site-one.it https://site-two.it https://site-three.it\\\" | redis-cli" && \
+docker-compose exec redis sh -c "echo SET 1 \\\"www.site-one.it site-two.it site-three.it\\\" | redis-cli" && \
 docker-compose exec redis sh -c "echo \"CONFIG SET protected-mode no\" | redis-cli" && \
 newman run WAI-Openresty.postman_collection.json && \
 docker-compose rm -f -s -v

--- a/images/wai-openresty/wai-csp.lua
+++ b/images/wai-openresty/wai-csp.lua
@@ -16,16 +16,16 @@ end
 local function has_value (arg, val)
   if arg == nil or val == ngx.null then
     return false
-end
-if type(arg) == "table" then
-  for index, value in ipairs(arg) do
-      if value == val then
-          return true
-      end
   end
-  return false
-end
-return type(arg) == "string" and arg == val
+  if type(arg) == "table" then
+    for index, value in ipairs(arg) do
+        if value == val then
+            return true
+        end
+    end
+    return false
+  end
+  return type(arg) == "string" and arg == val
 end
 
 local waicsp = {
@@ -39,7 +39,7 @@ function waicsp.evaluate(opts)
   local cspValue = opts.defaultCsp
   if (err ~= "truncated" and has_value(args["module"], "Widgetize") and has_value(args["action"], "iframe") and has_value(args["widget"], "1") and args["idSite"] ~= nil and type(args["idSite"]) == "string") then
     local referer = ngx.req.get_headers()["referer"]
-    if(referer == ngx.null or referer == nil) then
+    if (referer == ngx.null or referer == nil) then
       exit_401()
     end
     ngx_log(ngx_NOTICE, "Referer is " .. referer)
@@ -53,9 +53,9 @@ function waicsp.evaluate(opts)
         ngx.header["Content-Security-Policy"] = "frame-ancestors " .. cspValue
         return nil, err
     end
-    ngx_log(ngx_NOTICE, "Lookup to redis for keys on siteId " .. siteId )
+    ngx_log(ngx_NOTICE, "Lookup to redis for keys on siteId " .. siteId)
     local siteUrl = redis:get(siteId)
-    if(not _is_empty(siteUrl)) then
+    if (not _is_empty(siteUrl)) then
       cspValue = cspValue .. " " .. siteUrl
     end
     redis:close()
@@ -63,11 +63,11 @@ function waicsp.evaluate(opts)
     ngx_log(ngx_NOTICE, "Redis data is " .. cspValue)
     for host in string.gmatch(cspValue, '([^%s]+)') do
       ngx_log(ngx_NOTICE, "Testing '" .. referer .. "' on '" .. host .. "'")
-      if ( referer:find(host, 1, true) == 1 ) then
+      if (referer:find(host, 1, true) == 1) then
         match = true
       end
     end
-    if(match == false) then
+    if (match == false) then
       exit_401()
     end  
   end

--- a/images/wai-openresty/wai-csp.lua
+++ b/images/wai-openresty/wai-csp.lua
@@ -42,7 +42,9 @@ function waicsp.evaluate(opts)
     if (referer == ngx.null or referer == nil) then
       exit_401()
     end
-    ngx_log(ngx_NOTICE, "Referer is " .. referer)
+    local resty_url = require 'resty.url'
+    local referer_host = resty_url.parse(referer).host
+    ngx_log(ngx_NOTICE, "Referer host is " .. referer_host)
     local siteId = args["idSite"]
     ngx_log(ngx_NOTICE, "Parameters are ok. CSP procedure activated")
     local rc = require("resty.redis.connector").new()
@@ -62,8 +64,8 @@ function waicsp.evaluate(opts)
     local match = false
     ngx_log(ngx_NOTICE, "Redis data is " .. cspValue)
     for host in string.gmatch(cspValue, '([^%s]+)') do
-      ngx_log(ngx_NOTICE, "Testing '" .. referer .. "' on '" .. host .. "'")
-      if (referer:find(host, 1, true) == 1) then
+      ngx_log(ngx_NOTICE, "Testing '" .. referer_host .. "' on '" .. host .. "'")
+      if (referer_host:find(host, 1, true) == 1) then
         match = true
       end
     end


### PR DESCRIPTION
La cache popolata lato matomo/portal contiene solo l'elemento host (senza schema) perché per i siti istituzionali lo schema non è noto, dato che purtroppo non è presente in IndicePA.
Con questa PR si adatta lo script LUA presente in openresty all'uso del solo elemento host per la verifica del match tra `siteId` e l'header `Referer` e anche per il popolamento dell'header `CSP`. L'uso del solo host è permesso dalle [specifiche `CSP`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors).